### PR TITLE
allow perform bulk without id

### DIFF
--- a/include/elasticlient/bulk.h
+++ b/include/elasticlient/bulk.h
@@ -118,7 +118,9 @@ class Bulk {
      * \param connectionTimeout Elasticsearch node connection timeout.
      */
     Bulk(const std::vector<std::string> &hostUrlList,
-         std::int32_t connectionTimeout);
+         const std::string &user = "",
+         const std::string &password = "",
+         std::int32_t connectionTimeout = 6000);
     /**
      * Destroy bulk indexer, writing documents not yet indexed, discarding
      * possible errors. If you are interested in errors, call flush() and

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -51,6 +51,8 @@ class Client {
      * \param timeout      Elastic node connection timeout.
      */
     explicit Client(const std::vector<std::string> &hostUrlList,
+                    const std::string &user = "",
+                    const std::string &password = "",
                     std::int32_t timeout = 6000);
 
     Client(Client &&);

--- a/include/elasticlient/scroll.h
+++ b/include/elasticlient/scroll.h
@@ -54,6 +54,8 @@ class Scroll {
      * \param timeout Elasticsearch node connection timeout.
      */
     explicit Scroll(const std::vector<std::string> &hostUrlList,
+                    const std::string &user,
+                    const std::string &password,
                     std::size_t scrollSize = 100,
                     const std::string &scrollTimeout = "1m",
                     std::int32_t connectionTimeout = 6000);
@@ -104,6 +106,8 @@ class ScrollByScan : public Scroll {
 
     /// \see Scroll
     explicit ScrollByScan(const std::vector<std::string> &hostUrlList,
+                          const std::string &user = "",
+                          const std::string &password = "",
                           std::size_t scrollSize = 100,
                           const std::string &scrollTimeout = "1m",
                           int primaryShardsCount = 0,

--- a/src/bulk.cc
+++ b/src/bulk.cc
@@ -99,9 +99,11 @@ Bulk::Bulk(const std::shared_ptr<Client> &client)
 
 
 Bulk::Bulk(const std::vector<std::string> &hostUrlList,
+           const std::string &user,
+           const std::string &password,
            std::int32_t connectionTimeout)
   : impl(new Implementation(
-              std::make_shared<Client>(hostUrlList, connectionTimeout)))
+              std::make_shared<Client>(hostUrlList, user, password, connectionTimeout)))
 {}
 
 

--- a/src/bulk.cc
+++ b/src/bulk.cc
@@ -116,9 +116,14 @@ std::string createControl(const std::string &action,
                           const std::string &docId)
 {
     std::ostringstream out;
-    out << "{\"" << action << "\": {"
-           "\"_type\": \"" << docType << "\", "
-           "\"_id\": \"" << docId << "\"}}";
+    if(docId.empty()) {
+        out << "{\"" << action << "\": {"
+            "\"_type\": \"" << docType << "\"}}";
+    } else {
+        out << "{\"" << action << "\": {"
+            "\"_type\": \"" << docType << "\", "
+            "\"_id\": \"" << docId << "\"}}";
+    }
     return out.str();
 }
 

--- a/src/client-impl.h
+++ b/src/client-impl.h
@@ -39,19 +39,24 @@ class RandomUIntGenerator {
 class Client::Implementation {
     const std::vector<std::string> hostUrlList;
     cpr::Session session;
+    cpr::Authentication auth;
     uint32_t currentHostIndex, failCounter;
     RandomUIntGenerator uintGenerator;
 
     friend class Client;
 
   public:
-    Implementation(const std::vector<std::string> &hostUrlList, std::int32_t timeout)
-      : hostUrlList(hostUrlList), session(), currentHostIndex(0), failCounter(0), uintGenerator()
+    Implementation(const std::vector<std::string> &hostUrlList,
+                    const std::string &user,
+                    const std::string &password,
+                    std::int32_t timeout)
+      : hostUrlList(hostUrlList), session(), auth(user, password), currentHostIndex(0), failCounter(0), uintGenerator()
     {
         if (hostUrlList.empty()) {
             throw std::runtime_error("Hosts URL list can not be empty.");
         }
         session.SetTimeout(timeout);
+        session.SetAuth(auth);
         resetCurrentHostInfo();
     }
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -59,8 +59,10 @@ namespace elasticlient {
 
 
 Client::Client(const std::vector<std::string> &hostUrlList,
+               const std::string &user,
+               const std::string &password,
                std::int32_t timeout)
-  : impl(new Implementation(hostUrlList, timeout))
+  : impl(new Implementation(hostUrlList, user, password, timeout))
 {}
 
 

--- a/src/scroll.cc
+++ b/src/scroll.cc
@@ -23,11 +23,13 @@ Scroll::Scroll(const std::shared_ptr<Client> &client,
 
 
 Scroll::Scroll(const std::vector<std::string> &hostUrlList,
+               const std::string &user,
+               const std::string &password,
                std::size_t scrollSize,
                const std::string &scrollTimeout,
                std::int32_t connectionTimeout)
   : impl(new Implementation(
-      std::make_shared<Client>(hostUrlList, connectionTimeout), scrollSize, scrollTimeout))
+      std::make_shared<Client>(hostUrlList, user, password, connectionTimeout), scrollSize, scrollTimeout))
 {}
 
 
@@ -234,11 +236,13 @@ ScrollByScan::ScrollByScan(const std::shared_ptr<Client> &client,
 
 
 ScrollByScan::ScrollByScan(const std::vector<std::string> &hostUrlList,
+                           const std::string &user,
+                           const std::string &password,
                            std::size_t scrollSize,
                            const std::string &scrollTimeout,
                            int primaryShardsCount,
                            std::int32_t connectionTimeout)
-  : Scroll(hostUrlList, scrollSize, scrollTimeout, connectionTimeout)
+  : Scroll(hostUrlList, user, password, scrollSize, scrollTimeout, connectionTimeout)
 {
     if (primaryShardsCount != 0) {
         impl->scrollSize = (std::size_t) scrollSize / primaryShardsCount;

--- a/test/tests-elasticlient.cc
+++ b/test/tests-elasticlient.cc
@@ -229,6 +229,9 @@ TEST_F(ElasticlientTest, bulkInternal) {
     ASSERT_EQ(
         "{\"index\": {\"_type\": \"type1\", \"_id\": \"1\"}}",
         createControl("index", "type1", "1"));
+    ASSERT_EQ(
+        "{\"index\": {\"_type\": \"type1\"}}",
+        createControl("index", "type1", ""));
 
     // Create bulk with two elements
     SameIndexBulkData bulk("my_index");


### PR DESCRIPTION
As I know, Elasticsearch support bulk index without specifying the `_id`. However empty `_id` field in action metadata json is not allowed.
e.g.
```js
{ "index": { "_type": "type1", "_id": "" }} // fail
{ ... }
```

```js
{ "index": { "_type": "type1" }} // ok
{ ... }
```