### PR TITLE
Provide a way to connect to ES cluster via proxy server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -204,6 +204,16 @@ int main() {
 }
 ```
 
+## How to connect via http proxy
+
+Just use different constructor.
+```cpp
+elasticlient::Client client(
+    {"http://elastic1.host:9200/"}, 
+    6000,
+    {{"http", "http://proxy.host:8080"},{"https", "https://proxy.host:8080"}});
+```
+
 ## License
 Elasticlient is licensed under the MIT License (MIT). Only the [cmake/Modules/FindJsonCpp.cmake](cmake/Modules/FindJsonCpp.cmake) is originally licensed
 under [Boost Software License](cmake/Modules/LICENSE_1_0.txt), for more information see header of the file.

--- a/example/hello-world.cc
+++ b/example/hello-world.cc
@@ -14,6 +14,10 @@ int main() {
     // Prepare Client for nodes of one Elasticsearch cluster
     elasticlient::Client client({"http://elastic1.host:9200/"}); // last / is mandatory
 
+    // Or if you'd like to use proxy
+    //elasticlient::Client client({"http://elastic1.host:9200/"}, 6000,
+    //        {{"http", "http://proxy.host:8080"},{"https", "https://proxy.host:8080"}});
+
     std::string document {"{\"message\": \"Hello world!\"}"};
 
     // Index the document, index "testindex" must be created before

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -53,6 +53,13 @@ class Client {
     explicit Client(const std::vector<std::string> &hostUrlList,
                     std::int32_t timeout = 6000);
 
+    /**
+     * Initialize the Client.
+     * \param hostUrlList   Vector of URLs of Elasticsearch nodes in one Elasticsearch cluster.
+     *  Each URL in vector should end by "/".
+     * \param timeout       Elastic node connection timeout.
+     * \param proxyUrlList  List of used HTTP proxies.
+     */
     explicit Client(const std::vector<std::string> &hostUrlList,
                     std::int32_t timeout,
     explicit Client(

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -60,8 +60,6 @@ class Client {
      * \param timeout       Elastic node connection timeout.
      * \param proxyUrlList  List of used HTTP proxies.
      */
-    explicit Client(const std::vector<std::string> &hostUrlList,
-                    std::int32_t timeout,
     explicit Client(
         const std::vector<std::string> &hostUrlList,
         std::int32_t timeout,

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -51,8 +51,11 @@ class Client {
      * \param timeout      Elastic node connection timeout.
      */
     explicit Client(const std::vector<std::string> &hostUrlList,
-                    std::int32_t timeout = 6000,
-                    const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList = {});
+                    std::int32_t timeout = 6000);
+
+    explicit Client(const std::vector<std::string> &hostUrlList,
+                    std::int32_t timeout,
+                    const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList);
 
     Client(Client &&);
 

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -51,7 +51,8 @@ class Client {
      * \param timeout      Elastic node connection timeout.
      */
     explicit Client(const std::vector<std::string> &hostUrlList,
-                    std::int32_t timeout = 6000);
+                    std::int32_t timeout = 6000,
+                    const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList = {});
 
     Client(Client &&);
 

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -55,7 +55,10 @@ class Client {
 
     explicit Client(const std::vector<std::string> &hostUrlList,
                     std::int32_t timeout,
-                    const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList);
+    explicit Client(
+        const std::vector<std::string> &hostUrlList,
+        std::int32_t timeout,
+        const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList);
 
     Client(Client &&);
 

--- a/src/client-impl.h
+++ b/src/client-impl.h
@@ -57,7 +57,6 @@ class Client::Implementation {
         if (proxyUrlList.size()) {
             session.SetProxies(cpr::Proxies(proxyUrlList));
         }
-        session.SetProxies(proxies);
         session.SetTimeout(timeout);
         resetCurrentHostInfo();
     }

--- a/src/client-impl.h
+++ b/src/client-impl.h
@@ -53,7 +53,10 @@ class Client::Implementation {
         if (hostUrlList.empty()) {
             throw std::runtime_error("Hosts URL list can not be empty.");
         }
-        cpr::Proxies proxies(proxyUrlList);
+
+        if (proxyUrlList.size()) {
+            session.SetProxies(cpr::Proxies(proxyUrlList));
+        }
         session.SetProxies(proxies);
         session.SetTimeout(timeout);
         resetCurrentHostInfo();

--- a/src/client-impl.h
+++ b/src/client-impl.h
@@ -45,12 +45,16 @@ class Client::Implementation {
     friend class Client;
 
   public:
-    Implementation(const std::vector<std::string> &hostUrlList, std::int32_t timeout)
+    Implementation(const std::vector<std::string> &hostUrlList,
+            std::int32_t timeout,
+            const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList = {})
       : hostUrlList(hostUrlList), session(), currentHostIndex(0), failCounter(0), uintGenerator()
     {
         if (hostUrlList.empty()) {
             throw std::runtime_error("Hosts URL list can not be empty.");
         }
+        cpr::Proxies proxies(proxyUrlList);
+        session.SetProxies(proxies);
         session.SetTimeout(timeout);
         resetCurrentHostInfo();
     }

--- a/src/client.cc
+++ b/src/client.cc
@@ -59,10 +59,10 @@ namespace elasticlient {
 
 
 Client::Client(const std::vector<std::string> &hostUrlList,
-               std::int32_t timeout)
-  : impl(new Implementation(hostUrlList, timeout))
+               std::int32_t timeout,
+               const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList)
+  : impl(new Implementation(hostUrlList, timeout, proxyUrlList))
 {}
-
 
 Client::Client(Client &&) = default;
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -57,6 +57,10 @@ void fillRoutingInUrlPath(const std::string &routing, std::ostringstream &urlPat
 
 namespace elasticlient {
 
+Client::Client(const std::vector<std::string> &hostUrlList,
+               std::int32_t timeout)
+        : impl(new Implementation(hostUrlList, timeout, {}))
+{}
 
 Client::Client(const std::vector<std::string> &hostUrlList,
                std::int32_t timeout,

--- a/src/client.cc
+++ b/src/client.cc
@@ -59,7 +59,7 @@ namespace elasticlient {
 
 Client::Client(const std::vector<std::string> &hostUrlList,
                std::int32_t timeout)
-        : impl(new Implementation(hostUrlList, timeout, {}))
+  : impl(new Implementation(hostUrlList, timeout))
 {}
 
 Client::Client(const std::vector<std::string> &hostUrlList,


### PR DESCRIPTION
Proxy can by used to 
 - debug connection
 - change headers on the flight