### PR TITLE
Elasticlient ssl options by new header-only constructor.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -204,15 +204,43 @@ int main() {
 }
 ```
 
-## How to connect via http proxy
+## Elasticlient connection settings
 
-Just use different constructor.
+To setup various settings for the connection, option arguments can be passed into constructor.
 ```cpp
-elasticlient::Client client(
-    {"http://elastic1.host:9200/"}, 
-    6000,
-    {{"http", "http://proxy.host:8080"},{"https", "https://proxy.host:8080"}});
+    // Prepare Client for nodes of one Elasticsearch cluster.
+    // Various options could be passed into it - vector of the cluster nodes must be first
+    // but the rest of the arguments is order independent, and each is optional.
+    elasticlient::Client client(
+            {"http://elastic1.host:9200/"},
+            elasticlient::Client::TimeoutOption{30000},
+            elasticlient::Client::ConnectTimeoutOption{1000},
+            elasticlient::Client::ProxiesOption(
+                    {{"http", "http://proxy.host:8080"},
+                     {"https", "https://proxy.host:8080"}})
+    );
+
+    // each of these options can be set later as well
+    elasticlient::Client::SSLOption sslOptions {
+            elasticlient::Client::SSLOption::VerifyHost{true},
+            elasticlient::Client::SSLOption::VerifyPeer{true},
+            elasticlient::Client::SSLOption::CaInfo{"myca.pem"},
+            elasticlient::Client::SSLOption::CertFile{"mycert.pem"},
+            elasticlient::Client::SSLOption::KeyFile{"mycert-key.pem"}};
+    client.setClientOption(std::move(sslOptions));
+    client.setClientOption(elasticlient::Client::TimeoutOption{300000});
 ```
+
+Currently supported options:
+* `Client::TimeoutOption` - HTTP request timeout in ms.
+* `Client::ConnectTimeoutOption` - Connect timeout in ms.
+* `Client::ProxiesOption` - Proxy server settings.
+* `Client::SSLOption`
+  * `Client::SSLOption::CertFile` - path to the SSL certificate file.
+  * `Client::SSLOption::KeyFile` - path to the SSL certificate key file.
+  * `Client::SSLOption::CaInfo` - path to the CA bundle if custom CA is used.
+  * `Client::SSLOption::VerifyHost` - verify the certificate's name against host.
+  * `Client::SSLOption::VerifyPeer` - verify the peer's SSL certificate.
 
 ## License
 Elasticlient is licensed under the MIT License (MIT). Only the [cmake/Modules/FindJsonCpp.cmake](cmake/Modules/FindJsonCpp.cmake) is originally licensed

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -78,4 +78,15 @@ int main() {
 }
  * \endcode
  * You can also find this and more examples of basic usage of library <a href="https://github.com/seznam/elasticlient#how-to-use">here</a>.
+ *
+ * Templated version of the constructor \ref elasticlient::Client::Client accepts option arguments to set timeout, proxy servers or SSL. Just pass these instances to it in any order (just after vector of cluster nodes):
+ * - \ref elasticlient::Client::TimeoutOption - HTTP request timeout in ms.
+ * - \ref elasticlient::Client::ConnectTimeoutOption - Connect timeout in ms.
+ * - \ref elasticlient::Client::ProxiesOption - Proxy server settings.
+ * - \ref elasticlient::Client::SSLOption
+ *   - \ref elasticlient::Client::SSLOption::CertFile - path to the SSL certificate file.
+ *   - \ref elasticlient::Client::SSLOption::KeyFile - path to the SSL certificate key file.
+ *   - \ref elasticlient::Client::SSLOption::CaInfo - path to the CA bundle if custom CA is used.
+ *   - \ref elasticlient::Client::SSLOption::VerifyHost - verify the certificate's name against host.
+ *   - \ref elasticlient::Client::SSLOption::VerifyPeer - verify the peer's SSL certificate.
  */

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,3 +6,9 @@ add_executable(hello-world
 
 target_link_libraries(hello-world
                       ${ELASTICLIENT_LIBRARIES})
+
+add_executable(initializations
+               initializations.cc)
+
+target_link_libraries(initializations
+                      ${ELASTICLIENT_LIBRARIES})

--- a/example/initializations.cc
+++ b/example/initializations.cc
@@ -1,0 +1,44 @@
+/**
+ * \file
+ * Example elasticlient initialization.
+ */
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <cpr/response.h>
+#include <elasticlient/client.h>
+#include <elasticlient/logging.h>
+
+
+int main() {
+    // Setup logging from the elasticlient library if you want to know what is happening
+    elasticlient::setLogFunction([](elasticlient::LogLevel, const std::string &msg) {
+        std::cerr << msg << "\n";
+    });
+
+    elasticlient::Client::SSLOption sslOptions {
+            elasticlient::Client::SSLOption::VerifyHost{false},
+            elasticlient::Client::SSLOption::VerifyPeer{false},
+            elasticlient::Client::SSLOption::CaInfo{"myca.pem"},
+            elasticlient::Client::SSLOption::CertFile{"mycert.pem"},
+            elasticlient::Client::SSLOption::KeyFile{"mycert-key.pem"}};
+
+    // Prepare Client for nodes of one Elasticsearch cluster
+    // various options could be passed into it
+    elasticlient::Client client(
+            {"http://elastic1.host:9200/"},
+            elasticlient::Client::TimeoutOption{30000},
+            elasticlient::Client::ConnectTimeoutOption{1000},
+            sslOptions,
+            elasticlient::Client::ProxiesOption(
+                    {{"http", "http://proxy.host:8080"},
+                     {"https", "https://proxy.host:8080"}})
+    );
+
+    // or you can set options later one by one
+    client.setClientOption(elasticlient::Client::TimeoutOption{30000});
+
+    // and you can use client same as shown in hello-world.cc example...
+    cpr::Response retrievedDocument = client.get("testindex", "docType", "docId");
+}

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -10,6 +10,9 @@
 #include <cstdint>
 #include <stdexcept>
 #include <vector>
+#include <utility>
+#include <initializer_list>
+#include <type_traits>
 
 
 // Forward cpr::Response existence.
@@ -44,6 +47,151 @@ class Client {
         HEAD    = 4
     };
 
+    /// Abstract class for various options passed to Client constructor.
+    struct ClientOption {
+        virtual ~ClientOption() {}
+        /**
+         * Method to set option to the Client (internal impl).
+         * Set (derived) option specific settings to the implementation.
+         */
+        virtual void accept(Implementation &) const = 0;
+    };
+
+    /// Helper class holding single value for ClientOption implementations.
+    template <typename T>
+    struct ClientOptionValue: public ClientOption {
+        T value;
+
+        explicit ClientOptionValue(const T& value): value(value) {}
+        explicit ClientOptionValue(T&& value): value(std::move(value)) {}
+        ClientOptionValue(ClientOptionValue &&) = default;
+        virtual ~ClientOptionValue() = default;
+
+        T getValue() const {
+            return value;
+        }
+    };
+
+    /// The timeout [ms] setting for client connection.
+    struct TimeoutOption: public ClientOptionValue<std::int32_t> {
+        explicit TimeoutOption(std::int32_t timeoutMs)
+            : ClientOptionValue(timeoutMs) {}
+      protected:
+        void accept(Implementation &) const override;
+    };
+
+    /// The connection timeout [ms] for client.
+    struct ConnectTimeoutOption: public ClientOptionValue<std::int32_t> {
+        explicit ConnectTimeoutOption(std::int32_t timeoutMs)
+            : ClientOptionValue(timeoutMs) {}
+      protected:
+        void accept(Implementation &) const override;
+    };
+
+    /// Proxies option for client connection.
+    struct ProxiesOption: public ClientOption {
+        /// Implementation hidden from public interface.
+        class ProxiesOptionImplementation;
+        std::unique_ptr<ProxiesOptionImplementation> impl;
+
+        /**
+         * Set proxies to the client connection.
+         * \param proxies List of proxies consisting of the pair <protocol, proxy_url>.
+         */
+        explicit ProxiesOption(
+                const std::initializer_list<std::pair<const std::string, std::string>> &proxies);
+        ~ProxiesOption();
+      protected:
+        void accept(Implementation &) const override;
+    };
+
+    /// Options to setup SSL for client connection.
+    struct SSLOption: public ClientOption {
+        /// Implementation hidden from public interface.
+        class SSLOptionImplementation;
+        std::unique_ptr<SSLOptionImplementation> impl;
+
+        SSLOption();
+        SSLOption(SSLOption &&);
+        ~SSLOption();
+
+        /**
+         * Construct SSLOptions with various SSLOptionType options.
+         * All arguments passed to it must be base of SSLOptionType.
+         * If same types are passed, the last one overwrites preceeding one.
+         */
+        template <typename... T>
+        SSLOption(T... args): SSLOption() {
+            optSetter(std::move(args)...);
+        }
+
+        /// Abstract base class for specific SSL options.
+        struct SSLOptionType {
+            virtual ~SSLOptionType() {}
+            /// Visitor initiation to setup specific option by derived classes.
+            virtual void accept(SSLOptionImplementation &) const = 0;
+        };
+
+        /// Path to the certificate.
+        struct CertFile: public SSLOptionType {
+            explicit CertFile(std::string path): path(std::move(path)) {}
+            void accept(SSLOptionImplementation &) const override;
+            std::string path;
+        };
+
+        /// Path to the certificate key file.
+        struct KeyFile: public SSLOptionType {
+            explicit KeyFile(std::string path): path(std::move(path)) {}
+            void accept(SSLOptionImplementation &) const override;
+            std::string path;
+        };
+
+        /// Path to the custom CA bundle.
+        struct CaInfo: public SSLOptionType {
+            explicit CaInfo(std::string path): path(std::move(path)) {}
+            void accept(SSLOptionImplementation &) const override;
+            std::string path;
+        };
+
+        /// Flag whether to verify host.
+        struct VerifyHost: public SSLOptionType {
+            explicit VerifyHost(bool verify): verify(verify) {}
+            void accept(SSLOptionImplementation &) const override;
+            bool verify;
+        };
+
+        /// Flag whether to verify peer.
+        struct VerifyPeer: public SSLOptionType {
+            explicit VerifyPeer(bool verify): verify(verify) {}
+            void accept(SSLOptionImplementation &) const override;
+            bool verify;
+        };
+
+        /// Set single option - see SSLOptionType derived structs above.
+        void setSslOption(const SSLOptionType &);
+
+      protected:
+        void accept(Implementation &) const override;
+
+        /// Helper method to setup ssl options with SSLOptionType instances.
+        template <typename T>
+        void optSetter(T&& t) {
+            static_assert(std::is_base_of<SSLOptionType, T>::value,
+                          "Record must be derived from SSLOptionType");
+            setSslOption(std::forward<T>(t));
+        }
+
+        /// Helper method to setup ssl options with SSLOptionType instances.
+        template<typename T, typename... TRest>
+        void optSetter(T&& t, TRest&&... ts) {
+            static_assert(std::is_base_of<SSLOptionType, T>::value,
+                          "Record must be derived from SSLOptionType");
+            optSetter(std::forward<T>(t));
+            optSetter(std::move(ts)...);
+        }
+    };
+
+
     /**
      * Initialize the Client.
      * \param hostUrlList  Vector of URLs of Elasticsearch nodes in one Elasticsearch cluster.
@@ -65,9 +213,31 @@ class Client {
         std::int32_t timeout,
         const std::initializer_list<std::pair<const std::string, std::string>>& proxyUrlList);
 
+    /**
+     * Initialize the Client.
+     *
+     * Variadic arguments derived from ClientOption can be passed to it.
+     * The later option overwrites the preceeding one for same object types passed into it.
+     * \param hostUrlList   Vector of URLs of Elasticsearch nodes in one Elasticsearch cluster.
+     *                      Each URL in vector should end by "/".
+     */
+    template <typename... Opts>
+    Client(const std::vector<std::string> &hostUrlList,
+           Opts&&... opts)
+        : Client(hostUrlList)
+    {
+        optionConstructHelper(std::move(opts)...);
+    }
+
     Client(Client &&);
 
     ~Client();
+
+    /**
+     * Set single option derived from ClientOption to the client.
+     * \param opt Option to set. Has to be base of ClientOption.
+     */
+    void setClientOption(const ClientOption &opt);
 
     /**
      * Perform request on nodes until it is successful. Throws exception if all nodes
@@ -148,6 +318,23 @@ class Client {
                          const std::string &docType,
                          const std::string &id,
                          const std::string &routing = std::string());
+  private:
+    /// Helper method to setup client with ClientOption options.
+    template <typename T>
+    void optionConstructHelper(T&& opt) {
+        static_assert(std::is_base_of<ClientOption, T>::value,
+                      "Record must be derived from ClientOption");
+        setClientOption(std::forward<T>(opt));
+    }
+
+    /// Helper method to setup client with ClientOption options.
+    template <typename T, typename... TRest>
+    void optionConstructHelper(T&& opt, TRest&&... rest) {
+        static_assert(std::is_base_of<ClientOption, T>::value,
+                      "Record must be derived from ClientOption");
+        optionConstructHelper(std::forward<T>(opt));
+        optionConstructHelper(std::move(rest)...);
+    }
 };
 
 

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -141,9 +141,12 @@ class Client {
 
         /// Path to the certificate key file.
         struct KeyFile: public SSLOptionType {
-            explicit KeyFile(std::string path): path(std::move(path)) {}
+            explicit KeyFile(std::string path, std::string password = {})
+                : path(std::move(path)), password(std::move(password))
+            {}
             void accept(SSLOptionImplementation &) const override;
             std::string path;
+            std::string password;
         };
 
         /// Path to the custom CA bundle.

--- a/src/client-impl.h
+++ b/src/client-impl.h
@@ -15,6 +15,7 @@
 #include <thread>
 #include <time.h>
 #include <cpr/session.h>
+#include <cpr/proxies.h>
 #include "logging-impl.h"
 
 
@@ -99,6 +100,50 @@ class Client::Implementation {
     cpr::Response performRequest(Client::HTTPMethod method,
                                  const std::string &urlPath,
                                  const std::string &body = std::string());
+
+    /// Set client option from ClientOption derived classes.
+    void setClientOption(const ClientOption &opt) {
+        // invoke opt virtual method that will call visit() with specific type.
+        opt.accept(*this);
+    }
+
+    /// Set timeout from given instance.
+    void visit(const TimeoutOption &);
+    /// Set connection timeout from fiven instance.
+    void visit(const ConnectTimeoutOption &);
+    /// Set proxies from given instance.
+    void visit(const ProxiesOption &);
+    /// Set SSL options from given instance.
+    void visit(const SSLOption &);
+};
+
+
+class Client::SSLOption::SSLOptionImplementation {
+    /// SSL Options to set up.
+    cpr::SslOptions sslOptions;
+  public:
+    SSLOptionImplementation(): sslOptions() {}
+
+    const cpr::SslOptions &getOptions() const {
+        return sslOptions;
+    }
+
+    /// Set single option - derived from class SSLOptionType.
+    void setSslOption(const SSLOptionType &opt) {
+        // invoke opt virtual method that will call visit() with specific type.
+        opt.accept(*this);
+    }
+
+    /// Set certfile from given instance.
+    void visit(const CertFile &certFile);
+    /// Set keyfile from given instance.
+    void visit(const KeyFile &keyFile);
+    /// Set CA info from given instance.
+    void visit(const CaInfo &caBundle);
+    /// Set verify host flag from given option instance.
+    void visit(const VerifyHost &opt);
+    /// Set verify peer flag from given option instance.
+    void visit(const VerifyPeer &opt);
 };
 
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -313,7 +313,7 @@ void Client::SSLOption::SSLOptionImplementation::visit(const CertFile &certFile)
 }
 
 void Client::SSLOption::SSLOptionImplementation::visit(const KeyFile &keyFile) {
-    sslOptions.SetOption(cpr::ssl::KeyFile(std::string{keyFile.path}));
+    sslOptions.SetOption(cpr::ssl::KeyFile(keyFile.path, keyFile.password));
 }
 
 void Client::SSLOption::SSLOptionImplementation::visit(const CaInfo &caBundle) {


### PR DESCRIPTION
Added new header only constructor for `elasticlient::Client`, accepting variadic option arguments.
* `TimeoutOption` (already possible to set by other constructors)
* `ConnectTimeoutOption` (new)
* `ProxiesOption` (already possible to set by other constructors)
* `SSLOption` (new)

Constructor with variadic arguments could allow adding new options, as they are derived from same base class.

This header only stuff cannot be modified (unless some exceptions) in the future to keep API stable. It should not break binary compatibility, as only library clients are compiling it...