### PR TITLE
Changed document identifier to be optional

### DIFF
--- a/include/elasticlient/bulk.h
+++ b/include/elasticlient/bulk.h
@@ -66,7 +66,7 @@ class SameIndexBulkData: public IBulkData {
     /**
      * Add index document request to the bulk.
      * \param docType document type (as specified in mapping).
-     * \param id document ID.
+     * \param id document ID, for auto-generated ID use empty string.
      * \param doc Json document to index. Must not contain newline char.
      * \return true if bulk has reached its desired capacity.
      */
@@ -77,7 +77,7 @@ class SameIndexBulkData: public IBulkData {
     /**
      * Add create document request to the bulk.
      * \param docType document type (as specified in mapping).
-     * \param id document ID.
+     * \param id document ID, for auto-generated ID use empty string.
      * \param doc Json document to index. Must not contain newline char.
      * \return true if bulk has reached its desired capacity.
      */
@@ -88,7 +88,7 @@ class SameIndexBulkData: public IBulkData {
     /**
      * Add update document request to the bulk.
      * \param docType document type (as specified in mapping).
-     * \param id document ID.
+     * \param id document ID, for auto-generated ID use empty string.
      * \param doc Json document to index. Must not contain newline char.
      * \return true if bulk has reached its desired capacity.
      */

--- a/src/bulk-impl.h
+++ b/src/bulk-impl.h
@@ -19,14 +19,17 @@ namespace elasticlient {
 /**
  * Create control field for one bulk item.
  *
+ * If docId is empty, the Id will be automatically generated.
+ *
  * Something like that is produced for call:
  * \code
  *   createControl("index", "type1", "1");
  *   {"index": {"_type": "type1", "_id": "1"}}
  * \endcode
  */
-std::string createControl(
-        const std::string &action, const std::string &docType, const std::string &docId);
+std::string createControl(const std::string &action,
+                          const std::string &docType,
+                          const std::string &docId = "");
 
 
 struct BulkItem {

--- a/src/bulk.cc
+++ b/src/bulk.cc
@@ -126,8 +126,14 @@ std::string createControl(const std::string &action,
 {
     std::ostringstream out;
     out << "{\"" << action << "\": {"
-           "\"_type\": \"" << docType << "\", "
-           "\"_id\": \"" << docId << "\"}}";
+           "\"_type\": \"" << docType << "\"";
+
+    if (!docId.empty()) {
+        out << ", \"_id\": \"" << docId << "\"";
+    }
+
+    out << "}}";
+
     return out.str();
 }
 

--- a/test/tests-elasticlient.cc
+++ b/test/tests-elasticlient.cc
@@ -262,6 +262,11 @@ TEST_F(ElasticlientTest, bulkInternal) {
         "{\"index\": {\"_type\": \"type1\", \"_id\": \"1\"}}",
         createControl("index", "type1", "1"));
 
+    // check with empty Id field
+    ASSERT_EQ(
+        "{\"index\": {\"_type\": \"type1\"}}",
+        createControl("index", "type1", ""));
+
     // Create bulk with two elements
     SameIndexBulkData bulk("my_index");
     ASSERT_TRUE(bulk.empty());


### PR DESCRIPTION
While creating a document with an explicit identifier, Elasticsearch
needs to perform a check whether the same id already exists within the
same shard.

This patch makes setting document id optional. And using
auto-generated ids by leaving _id parameter, which makes indexing faster.

Signed-off-by: Ladislav Macoun <ladislavmacoun@gmail.com>