### PR TITLE
Add option build elasticlient lib statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ get_variable(ELASTICLIENT_VERSION_MINOR "Set elasticlient minor version." 1 NO)
 get_variable(ELASTICLIENT_VERSION_PATCH "Set elasticlient patch version." 0 NO)
 get_variable(BUILD_ELASTICLIENT_TESTS "Build tests for elasticlient library." YES YES)
 get_variable(BUILD_ELASTICLIENT_EXAMPLE "Build exmaple program which using elasticlient library." YES YES)
+get_variable(BUILD_SHARED_LIBS "Build shared libraries" ON YES)
 
 get_variable(USE_ALL_SYSTEM_LIBS "Will found all libraries in system." NO YES)
 if(USE_ALL_SYSTEM_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,14 @@
+if(BUILD_SHARED_LIBS)
+    set(ELASTICLIENT_STATICLIB NO)
+else()
+    set(ELASTICLIENT_STATICLIB YES)
+endif()
+
 include_directories(${ELASTICLIENT_INCLUDE_DIRS}
                     ${CPR_INCLUDE_DIRS}
                     ${JSONCPP_INCLUDE_DIRS})
 
-add_library(${ELASTICLIENT_LIBRARY} SHARED
+add_library(${ELASTICLIENT_LIBRARY}
             client.cc
             bulk.cc
             scroll.cc
@@ -13,14 +19,15 @@ add_library(${ELASTICLIENT_LIBRARY} SHARED
             "${ELASTICLIENT_INCLUDE_DIR}/elasticlient/bulk.h"
             "${ELASTICLIENT_INCLUDE_DIR}/elasticlient/scroll.h")
 
-target_link_libraries(${ELASTICLIENT_LIBRARY}
-                      ${JSONCPP_LIBRARIES}
-                      ${CPR_LIBRARIES})
-
 set_target_properties(${ELASTICLIENT_LIBRARY}
                       PROPERTIES
                           VERSION "${ELASTICLIENT_VERSION_MAJOR}.${ELASTICLIENT_VERSION_MINOR}.${ELASTICLIENT_VERSION_PATCH}"
-                          SOVERSION ${ELASTICLIENT_VERSION_MAJOR})
+                          SOVERSION ${ELASTICLIENT_VERSION_MAJOR}
+                          INTERFACE_COMPILE_DEFINITIONS ELASTICLIENT_STATICLIB)
+
+target_link_libraries(${ELASTICLIENT_LIBRARY}
+                      ${JSONCPP_LIBRARIES}
+                      ${CPR_LIBRARIES})
 
 install(TARGETS ${ELASTICLIENT_LIBRARY} LIBRARY
         DESTINATION lib)


### PR DESCRIPTION
The library will be build depending on the BUILD_SHARED_LIBS[1] flag.
This enables to build and link this library statically.

[1]: https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html

Signed-off-by: Ladislav Macoun <ladislavmacoun@gmail.com>