### PR TITLE
Added option to turn off document validation

### DIFF
--- a/include/elasticlient/bulk.h
+++ b/include/elasticlient/bulk.h
@@ -68,33 +68,40 @@ class SameIndexBulkData: public IBulkData {
      * \param docType document type (as specified in mapping).
      * \param id document ID, for auto-generated ID use empty string.
      * \param doc Json document to index. Must not contain newline char.
+     * \param validate checks whether string contains a newline, default true.
      * \return true if bulk has reached its desired capacity.
      */
-    bool indexDocument(
-            const std::string &docType, const std::string &id,
-            const std::string &doc);
+    bool indexDocument(const std::string &docType,
+                       const std::string &id,
+                       const std::string &doc,
+                       bool validate = true);
 
     /**
      * Add create document request to the bulk.
      * \param docType document type (as specified in mapping).
      * \param id document ID, for auto-generated ID use empty string.
      * \param doc Json document to index. Must not contain newline char.
+     * \param validate checks whether string contains a newline, default true.
      * \return true if bulk has reached its desired capacity.
      */
-    bool createDocument(
-            const std::string &docType, const std::string &id,
-            const std::string &doc);
+    bool createDocument(const std::string &docType,
+                        const std::string &id,
+                        const std::string &doc,
+                        bool validate = true);
 
     /**
      * Add update document request to the bulk.
      * \param docType document type (as specified in mapping).
      * \param id document ID, for auto-generated ID use empty string.
      * \param doc Json document to index. Must not contain newline char.
+     * \param validate checks whether string contains a newline, default true.
      * \return true if bulk has reached its desired capacity.
      */
     bool updateDocument(
-            const std::string &docType, const std::string &id,
-            const std::string &doc);
+            const std::string &docType,
+            const std::string &id,
+            const std::string &doc,
+            bool validate = true);
 
     /// Clear bulk (size() == 0 after this).
     void clear();

--- a/src/bulk.cc
+++ b/src/bulk.cc
@@ -49,29 +49,44 @@ std::string SameIndexBulkData::indexName() const {
 }
 
 
-bool SameIndexBulkData::indexDocument(
-        const std::string &docType, const std::string &id, const std::string &doc)
+bool SameIndexBulkData::indexDocument(const std::string &docType,
+                                      const std::string &id,
+                                      const std::string &doc,
+                                      bool validate)
 {
-    validateDocument(doc, id);
+    if (validate) {
+        validateDocument(doc, id);
+    }
+
     impl->data.emplace_back(createControl("index", docType, id), doc);
     // return true if bulk has reached its desired capacity
     return impl->data.size() >= impl->size;
 }
 
 
-bool SameIndexBulkData::createDocument(
-        const std::string &docType, const std::string &id, const std::string &doc)
+bool SameIndexBulkData::createDocument(const std::string &docType,
+                                       const std::string &id,
+                                       const std::string &doc,
+                                       bool validate)
 {
-    validateDocument(doc, id);
+    if (validate) {
+        validateDocument(doc, id);
+    }
+
     impl->data.emplace_back(createControl("create", docType, id), doc);
     // return true if bulk has reached its desired capacity
     return impl->data.size() >= impl->size;
 }
 
-bool SameIndexBulkData::updateDocument(
-        const std::string &docType, const std::string &id, const std::string &doc)
+bool SameIndexBulkData::updateDocument(const std::string &docType,
+                                       const std::string &id,
+                                       const std::string &doc,
+                                       bool validate)
 {
-    validateDocument(doc, id);
+    if (validate) {
+        validateDocument(doc, id);
+    }
+
     impl->data.emplace_back(createControl("update", docType, id), doc);
     // return true if bulk has reached its desired capacity
     return impl->data.size() >= impl->size;


### PR DESCRIPTION
For long string the validation is expensive, and often not necessary
since the doc could be validated during its
constructions/deserialization.

The option default to true, so previous API should not be broken.

Signed-off-by: Ladislav Macoun <ladislavmacoun@gmail.com>