### PR TITLE
Add Windows build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -Wall -Wextra -Wfatal-errors -Wformat-security -Wuninitialized -Wfloat-equal -fPIC -g")
+if(CMAKE_COMPILER_IS_GNUCXX)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -Wall -Wextra -Wfatal-errors -Wformat-security -Wuninitialized -Wfloat-equal -fPIC -g")
+endif(CMAKE_COMPILER_IS_GNUCXX)
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
 macro(get_variable VAR_NAME VAR_TEXT DEFAULT_VALUE IS_OPTION)

--- a/include/elasticlient/client.h
+++ b/include/elasticlient/client.h
@@ -14,6 +14,9 @@
 #include <initializer_list>
 #include <type_traits>
 
+#ifndef __GNUC__ 
+#undef DELETE
+#endif
 
 // Forward cpr::Response existence.
 namespace cpr {

--- a/include/elasticlient/logging.h
+++ b/include/elasticlient/logging.h
@@ -6,6 +6,9 @@
 #pragma once
 #include <string>
 
+#ifndef __GNUC__ 
+#undef ERROR
+#endif
 
 /// The elasticlient namespace
 namespace elasticlient {

--- a/src/client.cc
+++ b/src/client.cc
@@ -11,6 +11,9 @@
 #include <cpr/cpr.h>
 #include "logging-impl.h"
 
+#ifndef __GNUC__ 
+#undef DELETE
+#endif
 
 namespace {
 

--- a/src/logging-impl.h
+++ b/src/logging-impl.h
@@ -12,13 +12,22 @@
 #include <cstdio>
 #include <cstdarg>
 
-
-#define LOG(logLevel, args...)                                    \
+#ifdef __GNUC__ 
+#define LOG(logLevel, args ...)                                    \
     do {                                                          \
         if(elasticlient::isLoggingEnabled()) {                    \
             elasticlient::propagateLogMessage(logLevel, args);    \
         }                                                         \
     } while (false)
+#else
+#define LOG(logLevel, ...)                                    \
+    do {                                                          \
+        if(elasticlient::isLoggingEnabled()) {                    \
+            elasticlient::propagateLogMessage(logLevel, __VA_ARGS__);    \
+        }                                                         \
+    } while (false)
+#endif
+
 
 
 namespace elasticlient {
@@ -33,8 +42,11 @@ void dbgLog(LogLevel logLevel, const std::string &message);
 
 
 inline void propagateLogMessage(
-        LogLevel logLevel, const char* message, ...) __attribute__ ((format (printf, 2, 3)));
-
+        LogLevel logLevel, const char* message, ...) 
+#ifdef __GNUC__ 
+	__attribute__ ((format (printf, 2, 3)))
+#endif
+;
 
 void propagateLogMessage(LogLevel logLevel, const char* message, ...) {
     va_list args;

--- a/src/scroll.cc
+++ b/src/scroll.cc
@@ -11,6 +11,9 @@
 #include <cpr/cpr.h>
 #include "logging-impl.h"
 
+#ifndef __GNUC__ 
+#undef DELETE
+#endif
 
 namespace elasticlient {
 


### PR DESCRIPTION
I had the same issues as in https://github.com/seznam/elasticlient/issues/23, after little research of error messages I've found couple specific windows defines break building. Added straightforward fixes, probably not the best ones.

Build tested with:
```
cmake -DUSE_SYSTEM_HTTPMOCKSERVER=NO -DBUILD_ELASTICLIENT_TESTS=NO -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_WINSSL=YES -DUSE_OPENSSL=NO
```

For x86:
```
 -A WIN32 ..
```

Not sure which definition are best, so picked `__GNUC__`.
